### PR TITLE
Update package.json for yargs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "strip-ansi": "6.0",
     "text-table": "0.2",
     "tslib": "2.1.0",
-    "yargs": "15.4.1"
+    "yargs": "16.2.0"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",


### PR DESCRIPTION
The 15.4.1 version of yargs uses y18n@4.0.0, which flagged for having https://nvd.nist.gov/vuln/detail/CVE-2020-7774 issue, the yargs 16.2.0 uses y18n@5.0.5 there by addressing the issue.

Fixes #[ISSUE_NUMBER].

**Checklist**

- [ ] Tests added / updated
- [ ] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

> If indicated yes above, please describe the breaking change(s).
>
> **Remove this quote before creating the PR.**

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
